### PR TITLE
F 2 create blog feature

### DIFF
--- a/backend/app/Http/Controllers/api/BlogController.php
+++ b/backend/app/Http/Controllers/api/BlogController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Blog;
+use Illuminate\Http\Request;
+
+class BlogController extends Controller
+{
+    public function index()
+    {
+        $blogs = Blog::latest()->get();
+        return response()->json(['status' => 200, 'blogs' => $blogs], 200);
+    }
+}

--- a/backend/app/Http/Controllers/api/BlogController.php
+++ b/backend/app/Http/Controllers/api/BlogController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Blog;
 use Illuminate\Http\Request;
 use App\Http\Requests\BlogRequest;
+use Illuminate\Support\Str;
 
 class BlogController extends Controller
 {
@@ -23,8 +24,36 @@ class BlogController extends Controller
         $result = Blog::create($blog);
 
         if($result) {
-            return response()->json(['status' => 200, 'message' => ['success' => 'ブログを保存しました'], 200]);
+            return response()->json(['status' => 200, 'message' => ['success' => 'ブログを保存しました']], 200);
         }
-        return response()->json(['status' => 500, 'message' => ['error' => 'ブログを作成できませんでした'], 500]);
+        return response()->json(['status' => 500, 'message' => ['error' => 'ブログを作成できませんでした']], 500);
+    }
+
+    public function show($id)
+    {
+        $blog = Blog::find($id);
+        return response()->json(['status' => 200, 'blog' => $blog], 200);
+    }
+
+    public function edit($id)
+    {
+        $blog = Blog::findOrFail($id);
+        $planeBlog = $blog->getAttributes();
+        return response()->json(['status' => 200, 'blog' => $planeBlog], 200);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $editedBlog = $request->all();
+        $blog = Blog::find($id);
+        $blog->fill($editedBlog)->save();
+        return response()->json(['status' => 200, 'message' => ['success' => "{$blog->title}をアップデートしました"]], 200);
+    }
+
+    public function delete($id)
+    {
+        $blog = Blog::find($id);
+        $blog->delete();
+        return response()->json(['status' => 200, 'message' => ['success' => 'ブログを削除しました']], 200);
     }
 }

--- a/backend/app/Http/Controllers/api/BlogController.php
+++ b/backend/app/Http/Controllers/api/BlogController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\api;
 use App\Http\Controllers\Controller;
 use App\Models\Blog;
 use Illuminate\Http\Request;
+use App\Http\Requests\BlogRequest;
 
 class BlogController extends Controller
 {
@@ -12,5 +13,18 @@ class BlogController extends Controller
     {
         $blogs = Blog::latest()->get();
         return response()->json(['status' => 200, 'blogs' => $blogs], 200);
+    }
+
+    public function store(BlogRequest $request)
+    {
+        $blog = $request->all();
+        $blog['user_id'] = auth('sanctum')->user()->id;
+
+        $result = Blog::create($blog);
+
+        if($result) {
+            return response()->json(['status' => 200, 'message' => ['success' => 'ブログを保存しました'], 200]);
+        }
+        return response()->json(['status' => 500, 'message' => ['error' => 'ブログを作成できませんでした'], 500]);
     }
 }

--- a/backend/app/Http/Controllers/api/ImageController.php
+++ b/backend/app/Http/Controllers/api/ImageController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use App\Http\Requests\UploaderRequest;
+
+class ImageController extends Controller
+{
+
+    public function index(Request $request)
+    {
+        $allPath = collect(Storage::files('public/images/'));
+        $allUrl = $allPath->map(function($path, $key) {
+            return config('app.url') . Storage::url($path);
+        });
+
+        return response()->json(['allUrl' => $allUrl]);
+    }
+
+    public function store(UploaderRequest $request)
+    {
+        $image = $request->file('image');
+        $path = $image->store('public/images');
+
+        if($path) {
+            $url = config('app.url') . Storage::url($path);
+            return response()->json(['status'=> 200, 'url' => $url, 'message' => ['success' => '画像をアップロードしました']]);
+        }
+
+        return response()->json(['status' => 400, 'message' => ['error' => '画像を処理できませんでした']]);
+    }
+
+    public function destroy(Request $request)
+    {
+        $url = $request->url;
+        $path = str_replace(config('app.url') . '/storage/images/', '', $url);
+        $result = Storage::delete('public/images/' . $path);
+
+        if($result) {
+            return response()->json(['status'=> 200, 'success' => '画像を削除しました']);
+        }
+
+        return response()->json(['status' => 400, 'message' => ['error' => '画像を削除できませんでした']]);
+    }
+}

--- a/backend/app/Http/Requests/BlogRequest.php
+++ b/backend/app/Http/Requests/BlogRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class BlogRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->path() === 'api/v1/admin/blogs/store';
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|string|max:30',
+            'body' => 'required|string|',
+            'status' => 'required|integer|between:0,2',
+            'thummbnail' => 'required|url',
+        ];
+    }
+
+    /**
+     *  バリデーションメッセージ定義
+     * @return array
+     */
+    public function messages(): Array
+    {
+        return [
+            'required' => ':attributeが空ではなりません',
+            'string'   => ':attributeは文字列を入力してください',
+            'integer'  => ':attributeは数値を入力してください',
+            'between'  => ':attributeは:minから:maxの間の数値としてください',
+            'url'      => ':attributeのURLが不正です。',
+        ];
+    }
+
+    /**
+     *  バリデーション項目名定義
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            'title'      => 'タイトル',
+            'body'       => '本文',
+            'status'     => 'ステータス',
+            'thummbnail' => 'サムネイル'
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): HttpResponseException
+    {
+        $response = response()->json([
+            'status' => 400,
+            'message' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($response);
+    }
+}

--- a/backend/app/Http/Requests/LoginRequest.php
+++ b/backend/app/Http/Requests/LoginRequest.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 class LoginRequest extends FormRequest
 {
     /**
-     * FormRequestのるようが許可されているユーザーかを判断
+     * FormRequestが許可されているユーザーかを判断
      * trueなら許可、falseなら403を返し許可しないことを明示する
      * @return bool
      */

--- a/backend/app/Http/Requests/UploaderRequest.php
+++ b/backend/app/Http/Requests/UploaderRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class UploaderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return auth('sanctum')->user()? true : false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'image' => 'required|image',
+        ];
+    }
+
+        /**
+     *  バリデーションメッセージ定義
+     * @return array
+     */
+    public function messages(): Array
+    {
+        return [
+            'required' => ':attributeが空ではなりません',
+            'image'   => ':attributeは画像ファイルではありません',
+            'uploaded' => ':attributeのアップロードに失敗しました'
+        ];
+    }
+
+    /**
+     *  バリデーション項目名定義
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            'image' => '画像ファイル',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): HttpResponseException
+    {
+        $response = response()->json([
+            'status' => 400,
+            'message' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($response);
+    }
+}

--- a/backend/app/Models/Blog.php
+++ b/backend/app/Models/Blog.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Blog extends Model
+{
+    use HasFactory;
+}

--- a/backend/app/Models/Blog.php
+++ b/backend/app/Models/Blog.php
@@ -4,10 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Blog extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -25,5 +28,18 @@ class Blog extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * bodyはstring型のmarkdown形式で保存される
+     * アクセサでHTML変換とサニタイズ処理を施す
+     * @param string $value
+     * @return string
+     */
+    public function getBodyAttribute($value)
+    {
+        return Str::markdown($value, [
+            'html_input' => 'escape',
+        ]);
     }
 }

--- a/backend/app/Models/Blog.php
+++ b/backend/app/Models/Blog.php
@@ -8,4 +8,22 @@ use Illuminate\Database\Eloquent\Model;
 class Blog extends Model
 {
     use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'title',
+        'body',
+        'status',
+        'thummbnail',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -41,4 +41,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function blogs()
+    {
+        return $this->hasMany(Blog::class);
+    }
 }

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => ['http://localhost:3000'],
 
     'allowed_origins_patterns' => [],
 

--- a/backend/database/factories/BlogFactory.php
+++ b/backend/database/factories/BlogFactory.php
@@ -23,7 +23,7 @@ class BlogFactory extends Factory
             'title'       => $this->faker->title(),
             'body'        => $this->faker->realText($maxNbChars = 10, $indexSize = 2),
             'status'      => 1,
-            'thummbnail'  => '"./strage/public/image/MyIcon.jpeg"',
+            'thummbnail'  => '"http://localhost/storage/images/MyIcon.jpeg"',
         ];
     }
 }

--- a/backend/database/factories/BlogFactory.php
+++ b/backend/database/factories/BlogFactory.php
@@ -24,7 +24,6 @@ class BlogFactory extends Factory
             'body'        => $this->faker->realText($maxNbChars = 10, $indexSize = 2),
             'status'      => 1,
             'thummbnail'  => '"./strage/public/image/MyIcon.jpeg"',
-            'images_path' => json_encode(["./strage/public/image/MyIcon.jpeg"]),
         ];
     }
 }

--- a/backend/database/factories/BlogFactory.php
+++ b/backend/database/factories/BlogFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Blog;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Blog>
+ */
+class BlogFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id'     => User::factory(),
+            'title'       => $this->faker->title(),
+            'body'        => $this->faker->realText($maxNbChars = 10, $indexSize = 2),
+            'status'      => 1,
+            'thummbnail'  => '"./strage/public/image/MyIcon.jpeg"',
+            'images_path' => json_encode(["./strage/public/image/MyIcon.jpeg"]),
+        ];
+    }
+}

--- a/backend/database/migrations/2022_03_23_144241_create_blogs_table.php
+++ b/backend/database/migrations/2022_03_23_144241_create_blogs_table.php
@@ -20,7 +20,6 @@ return new class extends Migration
             $table->text('body');
             $table->integer('status');
             $table->string('thummbnail');
-            $table->json('images_path');
             $table->timestamps();
             $table->softDeletes();
         });

--- a/backend/database/migrations/2022_03_23_144241_create_blogs_table.php
+++ b/backend/database/migrations/2022_03_23_144241_create_blogs_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('blogs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->string('title');
+            $table->text('body');
+            $table->integer('status');
+            $table->string('thummbnail');
+            $table->json('images_path');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('blogs');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,8 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\Blog;
+use App\Models\User;
 
 class DatabaseSeeder extends Seeder
 {
@@ -15,5 +17,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         \App\Models\User::factory()->create();
+        \App\Models\Blog::factory()->create();
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\api\UserController;
+use App\Http\Controllers\api\BlogController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -20,4 +21,5 @@ Route::get('/logout', [UserController::class, 'logout']);
 
 Route::middleware('auth:sanctum')->group(function(){
     Route::get('/user', [UserController::class, 'show']);
+    Route::get('/admin/blogs/index', [BlogController::class, 'index']);
 });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\api\UserController;
 use App\Http\Controllers\api\BlogController;
+use App\Http\Controllers\api\ImageController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -22,4 +23,8 @@ Route::get('/logout', [UserController::class, 'logout']);
 Route::middleware('auth:sanctum')->group(function(){
     Route::get('/user', [UserController::class, 'show']);
     Route::get('/admin/blogs/index', [BlogController::class, 'index']);
+    Route::post('/admin/blogs/store', [BlogController::class, 'store']);
+    Route::get('/admin/images', [ImageController::class, 'index']);
+    Route::post('/admin/blog/image', [ImageController::class, 'store']);
+    Route::delete('/admin/blog/image', [ImageController::class, 'destroy']);
 });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,10 @@ Route::middleware('auth:sanctum')->group(function(){
     Route::get('/user', [UserController::class, 'show']);
     Route::get('/admin/blogs/index', [BlogController::class, 'index']);
     Route::post('/admin/blogs/store', [BlogController::class, 'store']);
+    Route::get('/admin/blogs/show/{id}', [BlogController::class, 'show']);
+    Route::get('/admin/blogs/edit/{id}', [BlogController::class, 'edit']);
+    Route::post('/admin/blogs/update/{id}', [BlogController::class, 'update']);
+    Route::delete('/admin/blogs/delete/{id}', [BlogController::class, 'delete']);
     Route::get('/admin/images', [ImageController::class, 'index']);
     Route::post('/admin/blog/image', [ImageController::class, 'store']);
     Route::delete('/admin/blog/image', [ImageController::class, 'destroy']);

--- a/backend/tests/Feature/BlogTest.php
+++ b/backend/tests/Feature/BlogTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Blog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * @see App/Http/Controllers/api/BlogController.php
+ *
+ */
+
+class BlogTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    protected $loginUrl = 'api/v1/login';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->post('/api/v1/csrf-cookie');
+    }
+
+    /** @test index */
+    function 認証されたユーザーはブログの一覧が返される()
+    {
+        $user = Sanctum::actingAs(
+            User::factory()->create(),
+            ['*']
+        );
+        Blog::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->get('api/v1/admin/blogs/index');
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'blogs',
+            ]);
+        
+    }
+
+    /** @test index */
+    function 認証されていないユーザーはブログの一覧が返されない()
+    {
+        $user = User::factory()->create();
+        Blog::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->get('api/v1/admin/blogs/index');
+
+        $response->assertStatus(500);
+    }
+}

--- a/backend/tests/Feature/BlogTest.php
+++ b/backend/tests/Feature/BlogTest.php
@@ -55,4 +55,55 @@ class BlogTest extends TestCase
 
         $response->assertStatus(500);
     }
+
+    /** @test store */
+    function ブログが作成される()
+    {
+        Sanctum::actingAs(
+            User::factory()->create(),
+            ['*']
+        );
+        $blog = [
+            'title' => 'test',
+            'body'  => 'body-test',
+            'status' => 1,
+            'thummbnail' => 'http://localhost/storage/images/pHhD0WxAK9vDFsnJzlfTKMC0nT5symfkVt2vRzF4.jpg',
+        ];
+
+        $response = $this->post('api/v1/admin/blogs/store', $blog);
+        $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'status',
+                    'message' => [
+                        'success'
+                    ],
+                ]);
+    }
+
+    /** @test store */
+    function ブログが作成されない()
+    {
+        Sanctum::actingAs(
+            User::factory()->create(),
+            ['*']
+        );
+        $blog = [
+            'title' => '',
+            'body'  => '',
+            'status' => '',
+            'thummbnail' => '',
+        ];
+
+        $response = $this->post('api/v1/admin/blogs/store', $blog);
+        $response->assertStatus(400)
+                ->assertJsonStructure([
+                    'status',
+                    'message' => [
+                        'title',
+                        'body',
+                        'status',
+                        'thummbnail',
+                    ],
+                ]);
+    }
 }

--- a/backend/tests/Feature/ImageTest.php
+++ b/backend/tests/Feature/ImageTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Blog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ImageTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    protected $loginUrl = 'api/v1/login';
+    protected $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        // ログイン処理
+        $this->post('/api/v1/csrf-cookie');
+        $this->user = Sanctum::actingAs(
+            User::factory()->create(),
+            ['*']
+        );
+    }
+
+    /** @test index */
+    public function ストレージのimageディレクトリ内の画像URLを全て取得する()
+    {
+        // モック作成
+        // Blog::factory()->create(['user_id' => $this->user->id]);
+    }
+}

--- a/backend/tests/Feature/UserTest.php
+++ b/backend/tests/Feature/UserTest.php
@@ -26,7 +26,7 @@ class UserTest extends TestCase
         $this->post('/api/v1/csrf-cookie');
     }
 
-    /** @test  */
+    /** @test  Login*/
     function ログインに成功すると200を返し認証される()
     {
         $user = User::factory()->create();
@@ -37,7 +37,7 @@ class UserTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /** @test  */
+    /** @test  Login*/
     function ログインに失敗した場合に400を返す()
     {
         User::factory()->create();
@@ -52,7 +52,7 @@ class UserTest extends TestCase
                 ]);
     }
 
-    /** @test  */
+    /** @test  Login*/
     function バリデーションエラーなら400を返し、エラーメッセージを返す()
     {
         User::factory()->create();

--- a/backend/tests/Feature/UserTest.php
+++ b/backend/tests/Feature/UserTest.php
@@ -48,7 +48,7 @@ class UserTest extends TestCase
         $response->assertStatus(400)
                 ->assertJson([
                     'status' => 400,
-                    'message' => 'Unauthorized',
+                    'message' => ['error' => '登録されていません'],
                 ]);
     }
 
@@ -63,7 +63,7 @@ class UserTest extends TestCase
         $response->assertStatus(400);
         $response->assertJson([
             'status' => 400,
-            'errors' => [
+            'message' => [
                 'email' => [
                     'メールアドレスを入力してください'
                 ],

--- a/frontend/components/admin/Sidebar.vue
+++ b/frontend/components/admin/Sidebar.vue
@@ -8,16 +8,22 @@
             <a-icon :type="fixed ? 'right' : 'left'" />
         </a-button>
         <a-menu-item key="1">
-            <a-icon type="inbox" />
-            <span>投稿一覧</span>
+            <nuxt-link to="/admin/BlogList">
+                <a-icon type="inbox" />
+                <span>投稿一覧</span>
+            </nuxt-link>
         </a-menu-item>
         <a-menu-item key="2">
-            <a-icon type="edit" />
-            <span>下書き一覧</span>
+            <nuxt-link to="/admin/BlogDraft">
+                <a-icon type="edit" />
+                <span>下書き一覧</span>
+            </nuxt-link>
         </a-menu-item>
         <a-menu-item key="3">
-            <a-icon type="picture" />
-            <span>画像アップロード</span>
+            <nuxt-link to="/admin/ImageUpload">
+                <a-icon type="picture" />
+                <span>画像アップロード</span>
+            </nuxt-link>
         </a-menu-item>
         <a-menu-item key="4" @click="logout">
             <a-icon type="user-delete" />

--- a/frontend/components/admin/blogs/CreateEdit.vue
+++ b/frontend/components/admin/blogs/CreateEdit.vue
@@ -1,0 +1,228 @@
+<template>
+    <div>
+        <a-form-model
+            ref="form"
+            :model="blog"
+            :rules="rules"
+        >
+            <a-form-model-item prop="title">
+                <a-input v-model="blog.title" size="large" :placeholder="$t('title')" />
+            </a-form-model-item>
+            <a-form-model-item prop="thummbnail">
+                <div class="thummbnail">
+                    <input
+                        type="file"
+                        ref="thummbnailInput"
+                        accept="image/*"
+                        @change.prevent="thummbnailAdd"
+                        :disabled="existThummbnail"
+                        class="hidden"
+                    />
+                    <div class="thummbnailUpload" :class="{ disabled:existThummbnail }" @click="thummbnailUpload" >{{ $t('thummbnailUpdate') }}</div>
+                    <div class="preview" v-show="existThummbnail">
+                        <a-button type="danger" class="delete-preview" @click.prevent="thummbnailDel">
+                            <a-icon type="delete" theme="filled" />
+                        </a-button>
+                        <img :src="blog.thummbnail">
+                    </div>
+                </div>
+            </a-form-model-item>
+            <mavon-editor ref="editor" language="ja" v-model="blog.body" @imgAdd="$imgAdd" @imgDel="$imgDel" style="z-index: 0;" :htmlCode="true" />
+            <a-form-model-item prop="status" style="marginTop: 15px">
+                <a-row type="flex" justify="end">
+                    <a-space>
+                        <a-select :default-value="blog.status" style="width: 120px" v-model="blog.status">
+                            <a-select-option :value="0">
+                                {{ $t('visible') }}
+                            </a-select-option>
+                            <a-select-option :value="1">
+                                {{ $t('draft') }}
+                            </a-select-option>
+                            <a-select-option :value="2">
+                                {{ $t('invisible') }}
+                            </a-select-option>
+                        </a-select>
+                        <a-popconfirm
+                            placement="topRight"
+                            ok-text="Yes"
+                            cancel-text="No"
+                            @confirm="onSubmit"
+                            @visibleChange="handleVisibleChange"
+                            :visible="createConfirm"
+                        >
+                            <template slot="title">
+                            <p>この記事は公開されますがよろしいですか？</p>
+                            </template>
+                            <a-button type="primary" :disabled="this.$app.isProcessing()">
+                                {{ $t('create') }}
+                            </a-button>
+                        </a-popconfirm>
+                        <a-button>
+                            {{ $t('preview') }}
+                        </a-button>
+                    </a-space>
+                </a-row>
+            </a-form-model-item>
+        </a-form-model>
+    </div>
+</template>
+
+<script>
+const VISIBLE = 0;
+const DRAFT = 1;
+const INVISIBLE = 2;
+
+export default {
+    name: 'CreateEdit',
+    layout: 'Layouts',
+    props: {
+        blog: {
+            type: Object,
+            default:() => ({
+                title      : '',
+                body       : '',
+                status     : 1,
+                thummbnail : '',
+            }),
+        },
+    },
+    data() {
+        return {
+            createConfirm: false,
+            rules: {
+                title: [
+                    { required: true, message: this.$t('validation.required'), trigger: 'blur' },
+                    { max: 30, message: this.$t('validation.max30'), trigger: 'blur' },
+                ],
+                status: [
+                    { required: true, message: this.$t('validation.required'), trigger: 'change' },
+                ]
+            }
+        }
+    },
+    computed: {
+        existThummbnail(){
+            return this.blog.thummbnail? true : false;
+        }
+    },
+    methods: {
+        async thummbnailAdd(event) {
+            let formData = this.createImageForm(event.target.files[0]);
+            let response = await this.imageUpload(formData);
+            if (response.status === 200) {
+                this.blog.thummbnail = response.url;
+                this.$message.success(response.message.success, 2.5);
+            }
+        },
+        async thummbnailDel() {
+            await this.deleteImage(this.blog.thummbnail);
+            this.blog.thummbnail = '';
+        },
+        async $imgAdd(pos, $file) {
+            let formData = this.createImageForm($file);
+            let response = await this.imageUpload(formData);
+            if (response.status === 200) {
+                return this.$refs.editor.$img2Url(pos, response.url);
+            }
+        },
+        async $imgDel(fileName) {
+            this.deleteImage(fileName[0])
+        },
+        async imageUpload(data) {
+            try {
+                this.$store.dispatch('process/isProcessing');
+                return await this.$axios.$post('admin/blog/image', data);
+            } catch(err){
+                this.showErrorMessage(err.response.data);
+                            console.log(err.response)
+                return err.response.data;
+            }
+        },
+        async deleteImage(imageUrl) {
+            try {
+                await this.$axios.$delete('admin/blog/image' + `?url=${imageUrl}`);
+            } catch(err) {
+                console.log(err);
+            }
+        },
+        createImageForm(data) {
+            let formData = new FormData();
+            formData.append('image', data);
+            return formData;
+        },
+        thummbnailUpload() {
+            this.$refs.thummbnailInput.click();
+        },
+        handleVisibleChange(visible) {
+            if (!visible) {
+                this.createConfirm = false;
+                return;
+            }
+            if (this.blog.status === VISIBLE) {
+                return this.createConfirm = true;
+            }
+            this.onSubmit();
+        },
+        onSubmit() {
+            this.$store.dispatch('process/isProcessing');
+            this.$refs.form.validate(async valid => {
+                if(valid) {
+                    this.$emit('blogPost', this.blog);
+                } else {
+                    console.log('validateError');
+                    return false;
+                }
+            });
+        }
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+.thummbnail {
+    display: flex;
+    .hidden {
+        display: none;
+    }
+    .thummbnailUpload {
+        cursor: pointer;
+        background-color: #4169e1;
+        padding: 0px 15px;
+        font-size: 12px;
+        font-weight: bold;
+        color: #fff;
+        border-radius: 100vh;
+        margin-right: 15px;
+        height: 40px;
+        &:hover {
+            background-color: #4169e1c6;
+        }
+    }
+    .disabled {
+        background-color: #c7cddcc6;
+        pointer-events: none;
+    }
+    .preview {
+        width: auto;
+        height: 50px;
+        position: relative;
+        .delete-preview {
+            width: 22px;
+            height: 22px;
+            padding: 0;
+            background-color: transparent;
+            border: none;
+            color: red;
+            position: absolute;
+            top: 0;
+            right: 0;
+        }
+        img {
+            height: 100%;
+        }
+    }
+    .status {
+        width: 100px;
+    }
+}
+</style>

--- a/frontend/lang/ja.js
+++ b/frontend/lang/ja.js
@@ -11,6 +11,7 @@ export default {
         integer: '数値ではありません',
         max30: '30文字以内でなければなりません'
     },
+    delete: '削除しました',
     blog: 'ブログ',
     title: 'タイトル',
     create: '作成',

--- a/frontend/lang/ja.js
+++ b/frontend/lang/ja.js
@@ -1,7 +1,7 @@
 export default {
     welcome: 'ようこそ',
     login: 'ログイン',
-    userEmail: 'ユーザー名',
+    userEmail: 'メールアドレス',
     password: 'パスワード',
     validation: {
         required: '空白ではいけません',

--- a/frontend/lang/ja.js
+++ b/frontend/lang/ja.js
@@ -1,11 +1,27 @@
 export default {
     welcome: 'ようこそ',
+    ServerError: 'InternalServerError',
     login: 'ログイン',
     userEmail: 'メールアドレス',
     password: 'パスワード',
     validation: {
         required: '空白ではいけません',
-        passRange: '6文字~12文字以内でなくてはなりません'
+        passRange: '6文字~12文字以内でなくてはなりません',
+        string: '文字列ではありません',
+        integer: '数値ではありません',
+        max30: '30文字以内でなければなりません'
     },
-    dashboard: 'ダッシュボード',
+    blog: 'ブログ',
+    title: 'タイトル',
+    create: '作成',
+    preview: 'プレビュー',
+    thummbnailUpdate: 'サムネイルのアップロード',
+    visible: '公開',
+    invisible: '非公開',
+    draft: '下書き',
+    pages: {
+        create: 'ブログ新規作成',
+        edit: 'ブログ編集',
+        show: 'ブログ詳細',
+    }, 
 }

--- a/frontend/layouts/Layouts.vue
+++ b/frontend/layouts/Layouts.vue
@@ -12,8 +12,8 @@
                 >
                     <AdminSidebar @fixed="fixedCollapsed" />
                 </a-layout-sider>
-                <a-layout-content style="padding: 15px;">
-                    <AdminContents />
+                <a-layout-content style="padding: 15px; height: 100vh;">
+                    <Nuxt />
                 </a-layout-content>
             </a-layout>
         </a-layout>
@@ -43,7 +43,6 @@ export default {
 }
 </script>
 
-<style>
-
+<style scoped>
 
 </style>

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -25,7 +25,10 @@ export default {
   plugins: [
     '@/plugins/antd-ui',
     '@/plugins/axios',
+    '@/plugins/day.js',
+    { src: '@/plugins/mixin-common-method.js', ssr:false },
     { src: '~/plugins/persistedstate.js', ssr: false},
+    { src: '@/plugins/vue-mavon-editor', ssr: false },
   ],
   ssr: false,
 
@@ -74,4 +77,9 @@ export default {
     port: 3000,
     host: '0.0.0.0'
   },
+
+  publicRuntimeConfig: {
+    BASE_URL: process.env.BASE_URL,
+    END_POINT: process.env.END_POINT,
+  }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,8 @@
         "ant-design-vue": "^1.7.8",
         "cookieparser": "^0.1.0",
         "core-js": "^3.19.3",
+        "dayjs": "^1.11.0",
+        "mavon-editor": "^2.10.4",
         "nuxt": "^2.15.8",
         "nuxt-client-init-module": "^0.3.0",
         "nuxt-i18n": "^6.28.1",
@@ -6386,6 +6388,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+    },
     "node_modules/cssnano": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
@@ -6558,6 +6565,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
+      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug=="
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -11645,6 +11657,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mavon-editor": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/mavon-editor/-/mavon-editor-2.10.4.tgz",
+      "integrity": "sha512-CFsBLkgt/KZBDg+SJYe2fyYv4zClY149PiwpH0rDAiiP4ae1XNs0GC8nBsoTeipsHcebDLN1QMkt3bUsnMDjQw==",
+      "dependencies": {
+        "xss": "^1.0.6"
       }
     },
     "node_modules/md5.js": {
@@ -18488,6 +18508,21 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xss": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.11.tgz",
+      "integrity": "sha512-EimjrjThZeK2MO7WKR9mN5ZC1CSqivSl55wvUK5EtU6acf0rzEE1pN+9ZDrFXJ82BRp3JL38pPE6S4o/rpp1zQ==",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -23496,6 +23531,11 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+    },
     "cssnano": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
@@ -23639,6 +23679,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
+      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -27480,6 +27525,14 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "mavon-editor": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/mavon-editor/-/mavon-editor-2.10.4.tgz",
+      "integrity": "sha512-CFsBLkgt/KZBDg+SJYe2fyYv4zClY149PiwpH0rDAiiP4ae1XNs0GC8nBsoTeipsHcebDLN1QMkt3bUsnMDjQw==",
+      "requires": {
+        "xss": "^1.0.6"
       }
     },
     "md5.js": {
@@ -32902,6 +32955,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xss": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.11.tgz",
+      "integrity": "sha512-EimjrjThZeK2MO7WKR9mN5ZC1CSqivSl55wvUK5EtU6acf0rzEE1pN+9ZDrFXJ82BRp3JL38pPE6S4o/rpp1zQ==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
     "ant-design-vue": "^1.7.8",
     "cookieparser": "^0.1.0",
     "core-js": "^3.19.3",
+    "dayjs": "^1.11.0",
+    "mavon-editor": "^2.10.4",
     "nuxt": "^2.15.8",
     "nuxt-client-init-module": "^0.3.0",
     "nuxt-i18n": "^6.28.1",

--- a/frontend/pages/admin/BlogDraft.vue
+++ b/frontend/pages/admin/BlogDraft.vue
@@ -1,15 +1,15 @@
 <template>
-    <div class="contents">
-        コンテンツ配置
+    <div>
+        下書き一覧
     </div>
 </template>
 
 <script>
 export default {
-
+    layout: 'Layouts',
 }
 </script>
 
-<style>
+<style scoped>
 
 </style>

--- a/frontend/pages/admin/BlogList.vue
+++ b/frontend/pages/admin/BlogList.vue
@@ -9,7 +9,7 @@
             </div>
             <a-list-item slot="renderItem" key="item.title" slot-scope="item, index">
                 <template v-for="{ type, text } in actions" slot="actions">
-                    <span :key="type" @click="type === 'edit'? editBlog(item.id) : null">
+                    <span :key="type" @click="clickIcon(type, item.id)">
                         <a-icon :type="type" style="margin-right: 8px" />
                         {{ text }}
                     </span>
@@ -18,7 +18,7 @@
                     slot="extra"
                     width="272"
                     alt="logo"
-                    :src="imagesUrlCreate + item.thummbnail"
+                    :src="item.thummbnail"
                 />
                 <nuxt-link :to="{ name: 'admin-blogs-show-id___ja', params: { id: item.id } }">
                     <a-list-item-meta :description="item.body">
@@ -41,6 +41,7 @@
 
 <script>
 export default {
+    name: 'BlogList',
     layout: 'Layouts',
     data() {
         return {
@@ -62,28 +63,34 @@ export default {
             ],
         }
     },
-    computed: {
-        imagesUrlCreate: function() {
-            return this.$config.END_POINT;
-        },
-    },
     methods: {
+        clickIcon(type, itemId) {
+            type === 'edit'? this.editBlog(itemId) : null;
+            type === 'delete'? this.deleteBlog(itemId) : null;
+        },
         editBlog(id) {
             console.log(id);
             this.$router.push({ name: "admin-blogs-edit-id___ja", params: { id } })
         },
-        hideBottom() {
-            console.log('bottom');
+        async deleteBlog(id) {
+            console.log(id);
+            try {
+                let response = await this.$axios.delete('/admin/blogs/delete/' + id);
+                this.blogs = this.blogs.filter((blog, index) => {
+                    return blog.id !== id;
+                });
+                return this.$message.success('削除しました', 2.5);
+            } catch(err) {
+                console.log(err);
+            }
         },
         async init() {
             try {
                 let response = await this.$axios.$get('/admin/blogs/index');
                 this.blogs = response.blogs;
-                console.log(response.blogs);
             } catch(err) {
                 console.log(err.response);
             }
-            window.addEventListener("scroll", this.hideBottom);
         },
     },
     created() {

--- a/frontend/pages/admin/BlogList.vue
+++ b/frontend/pages/admin/BlogList.vue
@@ -1,0 +1,111 @@
+<template>
+    <div>
+        <h2>
+            BlogsIndex
+        </h2>
+        <a-list item-layout="vertical" size="large" :pagination="pagination" :data-source="blogs">
+            <div slot="footer">
+                <b>PAST←TIME</b> GONPAPA
+            </div>
+            <a-list-item slot="renderItem" key="item.title" slot-scope="item, index">
+                <template v-for="{ type, text } in actions" slot="actions">
+                    <span :key="type" @click="type === 'edit'? editBlog(item.id) : null">
+                        <a-icon :type="type" style="margin-right: 8px" />
+                        {{ text }}
+                    </span>
+                </template>
+                <img
+                    slot="extra"
+                    width="272"
+                    alt="logo"
+                    :src="imagesUrlCreate + item.thummbnail"
+                />
+                <nuxt-link :to="{ name: 'admin-blogs-show-id___ja', params: { id: item.id } }">
+                    <a-list-item-meta :description="item.body">
+                        <a slot="title" :href="item.href">{{ item.title }}</a>
+                        <a-avatar slot="avatar" :src="item.avatar" />
+                    </a-list-item-meta>
+                </nuxt-link>
+                {{ item.content }}
+            </a-list-item>
+        </a-list>
+        <transition>
+            <div class="create-blog">
+                <nuxt-link :to="{ name: 'admin-blogs-create___ja' }" class="create-link">
+                    <a-icon type="select" style="{ fontSize: '24x', color: '#fff' }" />
+                </nuxt-link>
+            </div>
+        </transition>
+    </div>
+</template>
+
+<script>
+export default {
+    layout: 'Layouts',
+    data() {
+        return {
+            blogs: [],
+            pagination: {
+                onChange: page => {
+                console.log(page);
+                },
+                //ペジネーション後々追加
+                pageSize: 3,
+            },
+            actions: [
+                // 後々追加
+                { type: 'star-o', text: '0' },
+                { type: 'like-o', text: '0' },
+                { type: 'message', text: '0' },
+                { type: 'delete', text: '削除' },
+                { type: 'edit', text: 'edit' },
+            ],
+        }
+    },
+    computed: {
+        imagesUrlCreate: function() {
+            return this.$config.END_POINT;
+        },
+    },
+    methods: {
+        editBlog(id) {
+            console.log(id);
+            this.$router.push({ name: "admin-blogs-edit-id___ja", params: { id } })
+        },
+        hideBottom() {
+            console.log('bottom');
+        },
+        async init() {
+            try {
+                let response = await this.$axios.$get('/admin/blogs/index');
+                this.blogs = response.blogs;
+                console.log(response.blogs);
+            } catch(err) {
+                console.log(err.response);
+            }
+            window.addEventListener("scroll", this.hideBottom);
+        },
+    },
+    created() {
+        this.init();
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+.create-blog {
+    position: fixed;
+    bottom: 5%;
+    right: 5%;
+    background-color: #ccc;
+    padding: 15px;
+    border-radius: 50% 50%;
+    line-height: 0;
+    cursor: pointer;
+    .create-link {
+        color : inherit;    
+        font-size: 26px;
+        text-decoration : none;
+    }
+}
+</style>

--- a/frontend/pages/admin/ImageUpload.vue
+++ b/frontend/pages/admin/ImageUpload.vue
@@ -1,0 +1,34 @@
+<template>
+    <div>
+        画像一覧
+        <div v-for="url in imagesUrl" :key="url">
+            <img :src="url">
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    layout: 'Layouts',
+    data() {
+        return {
+            imagesUrl: ''
+        }
+    },
+    methods: {
+        async fetch() {
+            let response = await this.$axios.$get('/admin/images');
+            this.imagesUrl = response.allUrl
+            console.log(response);
+        }
+    },
+    created() {
+        this.fetch();
+
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/pages/admin/Login.vue
+++ b/frontend/pages/admin/Login.vue
@@ -79,7 +79,7 @@ export default {
         async handleSubmit() {
             let response = await this.$store.dispatch('login', this.credentials);
             if (response.status === 200) {
-                this.$router.push('/admin/dashboard');
+                this.$router.push('/admin/bloglist');
                 this.$message.success(response.message.success, 2.5);
             } else {
                 this.showErrorMessage(response);

--- a/frontend/pages/admin/blogs/create.vue
+++ b/frontend/pages/admin/blogs/create.vue
@@ -1,236 +1,32 @@
 <template>
     <div>
         <h2>{{ $t('pages.create') }}</h2>
-        <a-form-model
-            ref="form"
-            :model="blog"
-            :rules="rules"
-        >
-            <a-form-model-item prop="title">
-                <a-input v-model="blog.title" size="large" :placeholder="$t('title')" />
-            </a-form-model-item>
-            <a-form-model-item prop="thummbnail">
-                <div class="thummbnail">
-                    <input
-                        type="file"
-                        ref="thummbnailInput"
-                        accept="image/*"
-                        @change.prevent="thummbnailAdd"
-                        :disabled="existThummbnail"
-                        class="hidden"
-                    />
-                    <div class="thummbnailUpload" :class="{ disabled:existThummbnail }" @click="thummbnailUpload" >{{ $t('thummbnailUpdate') }}</div>
-                    <div class="preview" v-show="existThummbnail">
-                        <a-button type="danger" class="delete-preview" @click.prevent="thummbnailDel">
-                            <a-icon type="delete" theme="filled" />
-                        </a-button>
-                        <img :src="blog.thummbnail">
-                    </div>
-                </div>
-            </a-form-model-item>
-            <mavon-editor ref="editor" language="ja" v-model="blog.body" @imgAdd="$imgAdd" @imgDel="$imgDel" style="z-index: 0;" />
-            <a-form-model-item prop="status" style="marginTop: 15px">
-                <a-row type="flex" justify="end">
-                    <a-space>
-                        <a-select :default-value="blog.status" style="width: 120px" v-model="blog.status">
-                            <a-select-option :value="0">
-                                {{ $t('visible') }}
-                            </a-select-option>
-                            <a-select-option :value="1">
-                                {{ $t('draft') }}
-                            </a-select-option>
-                            <a-select-option :value="2">
-                                {{ $t('invisible') }}
-                            </a-select-option>
-                        </a-select>
-                        <a-popconfirm
-                            placement="topRight"
-                            ok-text="Yes"
-                            cancel-text="No"
-                            @confirm="onSubmit"
-                            @visibleChange="handleVisibleChange"
-                            :visible="createConfirm"
-                        >
-                            <template slot="title">
-                            <p>この記事は公開されますがよろしいですか？</p>
-                            </template>
-                            <a-button type="primary" :disabled="this.$app.isProcessing()">
-                                {{ $t('create') }}
-                            </a-button>
-                        </a-popconfirm>
-                        <a-button>
-                            {{ $t('preview') }}
-                        </a-button>
-                    </a-space>
-                </a-row>
-            </a-form-model-item>
-        </a-form-model>
+        <AdminBlogsCreateEdit @blogPost="blogCreate" />
     </div>
 </template>
 
 <script>
-const VISIBLE = 0;
-const DRAFT = 1;
-const INVISIBLE = 2;
-
 export default {
+    name: 'createBlog',
     layout: 'Layouts',
-    data() {
-        return {
-            blog: {
-                title      : '',
-                body       : '',
-                status     : 1,
-                thummbnail : '',
-            },
-            createConfirm: false,
-            rules: {
-                title: [
-                    { required: true, message: this.$t('validation.required'), trigger: 'blur' },
-                    { max: 30, message: this.$t('validation.max30'), trigger: 'blur' },
-                ],
-                status: [
-                    { required: true, message: this.$t('validation.required'), trigger: 'change' },
-                ]
-            }
-        }
-    },
-    computed: {
-        existThummbnail(){
-            return this.blog.thummbnail? true : false;
-        }
-    },
     methods: {
-        async thummbnailAdd(event) {
-            let formData = this.createImageForm(event.target.files[0]);
-            let response = await this.postImage(formData);
-            if (response.status === 200) {
-                this.blog.thummbnail = response.url;
+        async blogCreate(blog) {
+            try {
+                let response = await this.$axios.$post('/admin/blogs/store', blog);
+
+                this.$router.push('/admin/bloglist');
                 this.$message.success(response.message.success, 2.5);
-            }
-        },
-        async thummbnailDel() {
-            await this.deleteImage(this.blog.thummbnail);
-            this.blog.thummbnail = '';
-        },
-        async $imgAdd(pos, $file) {
-            let formData = this.createImageForm($file);
-            let response = await this.postImage(formData);
-            if (response.status === 200) {
-                return this.$refs.editor.$img2Url(pos, response.url);
-            }
-        },
-        async $imgDel(fileName) {
-            this.deleteImage(fileName[0])
-        },
-        async postImage(data) {
-            try {
-                this.$store.dispatch('process/isProcessing');
-                return await this.$axios.$post('admin/blog/image', data);
-            } catch(err){
-                this.showErrorMessage(err.response.data);
-                            console.log(err.response)
-                return err.response.data;
-            }
-        },
-        async deleteImage(imageUrl) {
-            try {
-                await this.$axios.$delete('admin/blog/image' + `?url=${imageUrl}`);
             } catch(err) {
-                console.log(err);
+                this.showErrorMessage(err.response.data);
             }
-        },
-        createImageForm(data) {
-            let formData = new FormData();
-            formData.append('image', data);
-            return formData;
-        },
-        thummbnailUpload() {
-            this.$refs.thummbnailInput.click();
         },
         showErrorMessage(response) {
             let arr = Object.keys(response.message);
             if (response.message.hasOwnProperty(arr[0])) {
                 return this.$message.error(response.message[arr[0]], 2.5);
             }
-            return this.$message.error($t('ServerError'), 2.5);
+            return this.$message.error('ServerError', 2.5);
         },
-        handleVisibleChange(visible) {
-            if (!visible) {
-                this.createConfirm = false;
-                return;
-            }
-            if (this.blog.status === VISIBLE) {
-                return this.createConfirm = true;
-            }
-            return this.onSubmit();
-        },
-        onSubmit() {
-            this.$store.dispatch('process/isProcessing');
-            this.$refs.form.validate(async valid => {
-                if(valid) {
-                    try {
-                        let response = await this.$axios.$post('/admin/blogs/store', this.blog);
-                        // 画面遷移処理
-                        this.$message.success(response.message.success, 2.5);
-                    } catch(err) {
-                        this.showErrorMessage(err.response.data);
-                    }
-                } else {
-                    console.log('validateError');
-                    return false;
-                }
-            });
-        }
     },
 }
 </script>
-
-<style lang="scss" scoped>
-.thummbnail {
-    display: flex;
-    .hidden {
-        display: none;
-    }
-    .thummbnailUpload {
-        cursor: pointer;
-        background-color: #4169e1;
-        padding: 0px 15px;
-        font-size: 12px;
-        font-weight: bold;
-        color: #fff;
-        border-radius: 100vh;
-        margin-right: 15px;
-        height: 40px;
-        &:hover {
-            background-color: #4169e1c6;
-        }
-    }
-    .disabled {
-        background-color: #c7cddcc6;
-        pointer-events: none;
-    }
-    .preview {
-        width: auto;
-        height: 50px;
-        position: relative;
-        .delete-preview {
-            width: 22px;
-            height: 22px;
-            padding: 0;
-            background-color: transparent;
-            border: none;
-            color: red;
-            position: absolute;
-            top: 0;
-            right: 0;
-        }
-        img {
-            height: 100%;
-        }
-    }
-    .status {
-        width: 100px;
-    }
-}
-</style>

--- a/frontend/pages/admin/blogs/create.vue
+++ b/frontend/pages/admin/blogs/create.vue
@@ -1,0 +1,236 @@
+<template>
+    <div>
+        <h2>{{ $t('pages.create') }}</h2>
+        <a-form-model
+            ref="form"
+            :model="blog"
+            :rules="rules"
+        >
+            <a-form-model-item prop="title">
+                <a-input v-model="blog.title" size="large" :placeholder="$t('title')" />
+            </a-form-model-item>
+            <a-form-model-item prop="thummbnail">
+                <div class="thummbnail">
+                    <input
+                        type="file"
+                        ref="thummbnailInput"
+                        accept="image/*"
+                        @change.prevent="thummbnailAdd"
+                        :disabled="existThummbnail"
+                        class="hidden"
+                    />
+                    <div class="thummbnailUpload" :class="{ disabled:existThummbnail }" @click="thummbnailUpload" >{{ $t('thummbnailUpdate') }}</div>
+                    <div class="preview" v-show="existThummbnail">
+                        <a-button type="danger" class="delete-preview" @click.prevent="thummbnailDel">
+                            <a-icon type="delete" theme="filled" />
+                        </a-button>
+                        <img :src="blog.thummbnail">
+                    </div>
+                </div>
+            </a-form-model-item>
+            <mavon-editor ref="editor" language="ja" v-model="blog.body" @imgAdd="$imgAdd" @imgDel="$imgDel" style="z-index: 0;" />
+            <a-form-model-item prop="status" style="marginTop: 15px">
+                <a-row type="flex" justify="end">
+                    <a-space>
+                        <a-select :default-value="blog.status" style="width: 120px" v-model="blog.status">
+                            <a-select-option :value="0">
+                                {{ $t('visible') }}
+                            </a-select-option>
+                            <a-select-option :value="1">
+                                {{ $t('draft') }}
+                            </a-select-option>
+                            <a-select-option :value="2">
+                                {{ $t('invisible') }}
+                            </a-select-option>
+                        </a-select>
+                        <a-popconfirm
+                            placement="topRight"
+                            ok-text="Yes"
+                            cancel-text="No"
+                            @confirm="onSubmit"
+                            @visibleChange="handleVisibleChange"
+                            :visible="createConfirm"
+                        >
+                            <template slot="title">
+                            <p>この記事は公開されますがよろしいですか？</p>
+                            </template>
+                            <a-button type="primary" :disabled="this.$app.isProcessing()">
+                                {{ $t('create') }}
+                            </a-button>
+                        </a-popconfirm>
+                        <a-button>
+                            {{ $t('preview') }}
+                        </a-button>
+                    </a-space>
+                </a-row>
+            </a-form-model-item>
+        </a-form-model>
+    </div>
+</template>
+
+<script>
+const VISIBLE = 0;
+const DRAFT = 1;
+const INVISIBLE = 2;
+
+export default {
+    layout: 'Layouts',
+    data() {
+        return {
+            blog: {
+                title      : '',
+                body       : '',
+                status     : 1,
+                thummbnail : '',
+            },
+            createConfirm: false,
+            rules: {
+                title: [
+                    { required: true, message: this.$t('validation.required'), trigger: 'blur' },
+                    { max: 30, message: this.$t('validation.max30'), trigger: 'blur' },
+                ],
+                status: [
+                    { required: true, message: this.$t('validation.required'), trigger: 'change' },
+                ]
+            }
+        }
+    },
+    computed: {
+        existThummbnail(){
+            return this.blog.thummbnail? true : false;
+        }
+    },
+    methods: {
+        async thummbnailAdd(event) {
+            let formData = this.createImageForm(event.target.files[0]);
+            let response = await this.postImage(formData);
+            if (response.status === 200) {
+                this.blog.thummbnail = response.url;
+                this.$message.success(response.message.success, 2.5);
+            }
+        },
+        async thummbnailDel() {
+            await this.deleteImage(this.blog.thummbnail);
+            this.blog.thummbnail = '';
+        },
+        async $imgAdd(pos, $file) {
+            let formData = this.createImageForm($file);
+            let response = await this.postImage(formData);
+            if (response.status === 200) {
+                return this.$refs.editor.$img2Url(pos, response.url);
+            }
+        },
+        async $imgDel(fileName) {
+            this.deleteImage(fileName[0])
+        },
+        async postImage(data) {
+            try {
+                this.$store.dispatch('process/isProcessing');
+                return await this.$axios.$post('admin/blog/image', data);
+            } catch(err){
+                this.showErrorMessage(err.response.data);
+                            console.log(err.response)
+                return err.response.data;
+            }
+        },
+        async deleteImage(imageUrl) {
+            try {
+                await this.$axios.$delete('admin/blog/image' + `?url=${imageUrl}`);
+            } catch(err) {
+                console.log(err);
+            }
+        },
+        createImageForm(data) {
+            let formData = new FormData();
+            formData.append('image', data);
+            return formData;
+        },
+        thummbnailUpload() {
+            this.$refs.thummbnailInput.click();
+        },
+        showErrorMessage(response) {
+            let arr = Object.keys(response.message);
+            if (response.message.hasOwnProperty(arr[0])) {
+                return this.$message.error(response.message[arr[0]], 2.5);
+            }
+            return this.$message.error($t('ServerError'), 2.5);
+        },
+        handleVisibleChange(visible) {
+            if (!visible) {
+                this.createConfirm = false;
+                return;
+            }
+            if (this.blog.status === VISIBLE) {
+                return this.createConfirm = true;
+            }
+            return this.onSubmit();
+        },
+        onSubmit() {
+            this.$store.dispatch('process/isProcessing');
+            this.$refs.form.validate(async valid => {
+                if(valid) {
+                    try {
+                        let response = await this.$axios.$post('/admin/blogs/store', this.blog);
+                        // 画面遷移処理
+                        this.$message.success(response.message.success, 2.5);
+                    } catch(err) {
+                        this.showErrorMessage(err.response.data);
+                    }
+                } else {
+                    console.log('validateError');
+                    return false;
+                }
+            });
+        }
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+.thummbnail {
+    display: flex;
+    .hidden {
+        display: none;
+    }
+    .thummbnailUpload {
+        cursor: pointer;
+        background-color: #4169e1;
+        padding: 0px 15px;
+        font-size: 12px;
+        font-weight: bold;
+        color: #fff;
+        border-radius: 100vh;
+        margin-right: 15px;
+        height: 40px;
+        &:hover {
+            background-color: #4169e1c6;
+        }
+    }
+    .disabled {
+        background-color: #c7cddcc6;
+        pointer-events: none;
+    }
+    .preview {
+        width: auto;
+        height: 50px;
+        position: relative;
+        .delete-preview {
+            width: 22px;
+            height: 22px;
+            padding: 0;
+            background-color: transparent;
+            border: none;
+            color: red;
+            position: absolute;
+            top: 0;
+            right: 0;
+        }
+        img {
+            height: 100%;
+        }
+    }
+    .status {
+        width: 100px;
+    }
+}
+</style>

--- a/frontend/pages/admin/blogs/edit/_id.vue
+++ b/frontend/pages/admin/blogs/edit/_id.vue
@@ -1,0 +1,14 @@
+<template>
+    <div>
+        edit
+    </div>
+</template>
+<script>
+export default {
+    layout: 'Layouts',
+}
+
+</script>
+<style>
+
+</style>

--- a/frontend/pages/admin/blogs/edit/_id.vue
+++ b/frontend/pages/admin/blogs/edit/_id.vue
@@ -1,11 +1,48 @@
 <template>
     <div>
-        edit
+        <h2>{{ $t('pages.edit') }}</h2>
+        <AdminBlogsCreateEdit :blog="blog" @blogPost="blogUpdate" />
     </div>
 </template>
 <script>
 export default {
     layout: 'Layouts',
+    data() {
+        return {
+            blog: {},
+        }
+    },
+    methods: {
+        async init() {
+            try {
+                let response = await this.$axios.$get('/admin/blogs/edit/' + this.$route.params.id);
+                this.blog = response.blog;
+                console.log(this.blog)
+            } catch(err) {
+
+            }
+        },
+        async blogUpdate(blog) {
+            try {
+                let response = await this.$axios.$post('/admin/blogs/update/' + this.$route.params.id, blog);
+
+                this.$router.push('/admin/bloglist');
+                this.$message.success(response.message.success, 2.5);
+            } catch(err) {
+                this.showErrorMessage(err.response.data);
+            }
+        },
+        showErrorMessage(response) {
+            let arr = Object.keys(response.message);
+            if (response.message.hasOwnProperty(arr[0])) {
+                return this.$message.error(response.message[arr[0]], 2.5);
+            }
+            return this.$message.error('ServerError', 2.5);
+        },
+    },
+    created() {
+        this.init();
+    },
 }
 
 </script>

--- a/frontend/pages/admin/blogs/show/_id.vue
+++ b/frontend/pages/admin/blogs/show/_id.vue
@@ -1,0 +1,14 @@
+<template>
+    <div>
+        show
+    </div>
+</template>
+<script>
+export default {
+    layout: 'Layouts',
+}
+
+</script>
+<style>
+
+</style>

--- a/frontend/pages/admin/blogs/show/_id.vue
+++ b/frontend/pages/admin/blogs/show/_id.vue
@@ -1,14 +1,51 @@
 <template>
     <div>
-        show
+        <h2><a-icon type="file-text" />ブログ詳細</h2>
+        <div class="warpper-img">
+            <a-space size="large">
+                <img :src="blog.thummbnail" alt="サムネイル">
+                <h2>{{ blog.title }}</h2>
+            </a-space>
+        </div>
+        <mavon-editor
+            v-model="blog.body"
+            :subfield="false"
+            defaultOpen="preview"
+            :toolbarsFlag="false"
+        />
+        <div v-html="blog.body">
+
+        </div>
     </div>
 </template>
 <script>
 export default {
     layout: 'Layouts',
+    data() {
+        return {
+            blog: {},
+        }
+    },
+    methods: {
+        async getBlog() {
+            let response = await this.$axios.$get('/admin/blogs/show/' + this.$route.params.id);
+            console.log(response);
+            this.blog = response.blog;
+        },
+    },
+    created() {
+        this.getBlog();
+    },
 }
 
 </script>
-<style>
+<style lang="scss" scoped>
+.warpper-img {
+    display: flex;
+    margin-bottom: 10px;
+    img {
+        max-width: 200px;
+    }
+}
 
 </style>

--- a/frontend/plugins/day.js
+++ b/frontend/plugins/day.js
@@ -1,0 +1,5 @@
+import dayjs from 'dayjs'
+
+export default ({ app }, inject) => {
+    inject('dayjs', ((string) => dayjs(string)));
+}

--- a/frontend/plugins/mixin-common-method.js
+++ b/frontend/plugins/mixin-common-method.js
@@ -1,0 +1,8 @@
+export default ({ store }, inject) => {
+    const app = {
+        isProcessing: () => {
+            return store.getters['process/getIsProcessing'];
+        },
+    }
+    inject('app', app)
+}

--- a/frontend/plugins/vue-mavon-editor.js
+++ b/frontend/plugins/vue-mavon-editor.js
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+import mavonEditor from 'mavon-editor';
+import 'mavon-editor/dist/css/index.css';
+
+Vue.use(mavonEditor);

--- a/frontend/store/process.js
+++ b/frontend/store/process.js
@@ -15,7 +15,6 @@ export const mutations = {
 export const actions = {
     isProcessing({ commit }) {
         commit('setProcess', true);
-        console.log('fafafa');
         setTimeout(() => {
             commit('setProcess', false);
         }, 1000);

--- a/frontend/store/process.js
+++ b/frontend/store/process.js
@@ -1,0 +1,23 @@
+export const state = () => ({
+    isProcessing: false,
+});
+
+export const getters = {
+    getIsProcessing: state => state.isProcessing,
+};
+
+export const mutations = {
+    setProcess(state, isProcessing) {
+        state.isProcessing = isProcessing;
+    },
+};
+
+export const actions = {
+    isProcessing({ commit }) {
+        commit('setProcess', true);
+        console.log('fafafa');
+        setTimeout(() => {
+            commit('setProcess', false);
+        }, 1000);
+    }
+};

--- a/frontend/test/admin/BlogList.spec.js
+++ b/frontend/test/admin/BlogList.spec.js
@@ -1,0 +1,56 @@
+import { shallowMount, RouterLinkStub } from '@vue/test-utils'
+import BlogList from '@/pages/admin/BlogList'
+
+const response = {
+    "status": 200,
+    "blogs": [
+        {
+            "id": 5,
+            "user_id": 26,
+            "title": "Prof.",
+            "body": "Alice, as she spoke; 'either you or your head must be collected at once took up the little thing was snorting like a snout than a real nose; also its eyes again, to see if there are, nobody attends to them--and you've no idea how confusing it is I hate cats and dogs.' It was all dark overhead; before her was another long passage, and the Panther were sharing a pie--' [later editions continued as follows When the sands are all dry, he is gay as a last resource, she put them into a line along the sea-shore--' 'Two lines!' cried the Gryphon, 'she wants for to know when the tide rises and sharks are around, His voice has a timid voice at her as she could not join the dance. So they began moving about again, and we put a white one in by mistake; and if I know I have done that, you know,' said Alice in a low, timid voice, 'If you knew Time as well go back, and barking hoarsely all the right size to do it! Oh dear! I'd nearly forgotten to ask.' 'It turned into a conversation. 'You don't.",
+            "status": 1,
+            "thummbnail": "\/storage\/images\/MyIcon.jpeg",
+            "images_path": "[\".\\\/strage\\\/public\\\/image\\\/MyIcon.jpeg\"]",
+            "created_at": "2022-03-24T14:16:18.000000Z",
+            "updated_at": "2022-03-24T14:16:18.000000Z",
+            "deleted_at": null
+        },
+        {
+            "id": 6,
+            "user_id": 26,
+            "title": "Prof.",
+            "body": "xafga",
+            "status": 1,
+            "thummbnail": "\/storage\/images\/MyIcon.jpeg",
+            "images_path": "[\".\\\/strage\\\/public\\\/image\\\/MyIcon.jpeg\"]",
+            "created_at": "2022-03-24T14:16:18.000000Z",
+            "updated_at": "2022-03-24T14:16:18.000000Z",
+            "deleted_at": null
+        }
+    ]
+}
+
+describe('ブログリストが正常に表示されている', () => {
+    const init = jest.fn();
+    init.mockReturnValue(response);
+    const wrapper = shallowMount(BlogList, {
+        stubs: {
+            NuxtLink: RouterLinkStub,
+        },
+        methods: {
+            init,
+        },
+        $config: {
+            END_POINT: 'http://localhost'
+        }
+    });
+
+    beforeAll(() => {
+        return wrapper.vm.blogs = response.blogs;
+    })
+
+    test('ブログリストが表示されていること', () => {
+        expect(wrapper.text()).toMatch('削除');
+    })
+})

--- a/frontend/test/admin/Login.spec.js
+++ b/frontend/test/admin/Login.spec.js
@@ -36,7 +36,7 @@ describe('ログイン正常系', () => {
         submit.trigger('submit.prevent');
 
         setTimeout(() => {
-            expect(mockRouterPush.push).toHaveBeenCalledWith('/admin/dashboard');
+            expect(mockRouterPush.push).toHaveBeenCalledWith('/admin/bloglist');
             done();
         });
     });

--- a/frontend/test/admin/Login.spec.js
+++ b/frontend/test/admin/Login.spec.js
@@ -3,15 +3,19 @@ import Login from '@/pages/admin/login.vue'
 
 describe('ログイン正常系', () => {
     const mockRouterPush = {
-        push: jest.fn()
+        push: jest.fn(),
+    }
+    const dispatch = {
+        dispatch: () => JSON.parse('{ "status": 200, "message": {"success": "ログインしました" }}'),
     }
     const wrapper = mount(Login, {
         mocks: {
-            $router: mockRouterPush
+            $router: mockRouterPush,
+            $store: dispatch,
         }
     });
-    test('ユーザー名入力欄が存在すること', () => {
-        expect(wrapper.text()).toMatch('ユーザー名');
+    test('メールアドレス入力欄が存在すること', () => {
+        expect(wrapper.text()).toMatch('メールアドレス');
         const loginInput = wrapper.findComponent('.login-input');
         expect(loginInput.exists()).toBe(true);
     });
@@ -25,25 +29,28 @@ describe('ログイン正常系', () => {
         expect(submit.exists()).toBe(true);
         expect(submit.findComponent('span').text()).toMatch('ログイン');
     });
-    test('正常にユーザー名とパスワードを入力後、サブミットしたらダッシュボードへ遷移する', () => {
+    test('正常にメールアドレスとパスワードを入力後、サブミットしたらダッシュボードへ遷移する', done => {
         const submit = wrapper.findComponent('form');
-        wrapper.findComponent('.login-input input').setValue('userName');
-        wrapper.findComponent('.password-input input').setValue('secret');
+        wrapper.findComponent('.login-input input').setValue('a@a.com');
+        wrapper.findComponent('.password-input input').setValue('password');
         submit.trigger('submit.prevent');
-        expect(mockRouterPush.push).toHaveBeenCalledWith('/admin/dashboard');
+
+        setTimeout(() => {
+            expect(mockRouterPush.push).toHaveBeenCalledWith('/admin/dashboard');
+            done();
+        });
     });
-    //バリデーションが効かないことのテスト
 });
 
 describe('ログイン異常系', () => {
     const wrapper = mount(Login);
 
-    test('ユーザー名が空白ならエラー出力のこと', done => {
+    test('メールアドレスが空白ならエラー出力のこと', done => {
         const submit = wrapper.findComponent('form');
         wrapper.findComponent('.login-input input').setValue('');
         submit.trigger('submit.prevent');
         setTimeout(() => {
-            expect(wrapper.text()).toMatch('name is required');
+            expect(wrapper.text()).toMatch('email is required');
             done()
         })
     });
@@ -75,10 +82,3 @@ describe('ログイン異常系', () => {
         })
     });
 });
-
-// data-test-id="test-target"
-//バリデーションテスト
-//dataの確認
-//フォームの送信作
-//フォームに送るデータ
-//サーバーからの失敗時の挙動

--- a/frontend/test/admin/dashboard/dashboard.spec.js
+++ b/frontend/test/admin/dashboard/dashboard.spec.js
@@ -1,2 +1,0 @@
-import { mount } from '@vue/test-utils'
-import Login from '@/pages/admin/login.vue'


### PR DESCRIPTION
ブログ作成API作成
-ブログモデルとイメージアップロードモデルを作成
-Userモデルとブログモデルのリレーション作成(1対多)

Nuxtのディレクトリ構成を変更
-Layoutのlayout-content中でのみ画面遷移を行うようにした(ヘッダーサイドバーは固定)
-ブログCRUD追加
-ブログ作成と編集の共用化
-ダブルクリック多重送信を防ぐ(プラグインとしてNuxtに組み込み)
-画像アップロード画面で、とりあえずサーバー内にある画像を取得だけしてデザイン、機能等は未着手