### PR TITLE
セッション切れの際にログイン画面にリダイレクト処理

### DIFF
--- a/backend/app/Http/Controllers/api/UserController.php
+++ b/backend/app/Http/Controllers/api/UserController.php
@@ -100,4 +100,13 @@ class UserController extends Controller
         auth()->logout();
         return response()->json(['status' => 200, 'message' => ['success' => 'ログアウトしました']], 200);
     }
+
+    /**
+     * 認証チェック
+     */
+    public function checkAuth()
+    {
+        $result = auth()->check();
+        return response()->json(['status' => 200, 'message' => ['result' => $result], 200]);
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::post('/login', [UserController::class, 'login']);
 Route::get('/logout', [UserController::class, 'logout']);
+Route::get('/check-auth', [UserController::class, 'checkAuth']);
 
 Route::middleware('auth:sanctum')->group(function(){
     Route::get('/user', [UserController::class, 'show']);

--- a/frontend/middleware/auth.js
+++ b/frontend/middleware/auth.js
@@ -1,10 +1,18 @@
-export default function ({ store, route, app }) {
+export default async function ({ store, route, app }) {
     if (route.name !== 'admin-Login___ja') {
-        let session = sessionStorage.getItem('pasttime');
-        let sessionItem = JSON.parse(session);
-        if(sessionItem.user == null){
-            console.log(app.router);
-            return app.router.push('/admin/login');
+        try {
+            let response = await app.$axios.$get('/check-auth');
+            if(!response.message.result) {
+                resetAuth();
+            }
+        } catch(err) {
+            console.log(err);
+            resetAuth();
         }
+    }
+
+    const resetAuth= () => {
+        sessionStorage.removeItem('pasttime');
+        return app.router.push('/admin/login');
     }
 }

--- a/frontend/pages/admin/Login.vue
+++ b/frontend/pages/admin/Login.vue
@@ -38,6 +38,7 @@
 
 <script>
 export default {
+    name: 'Login',
     data() {
         return {
             credentials: {

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -33,8 +33,7 @@ export const actions = {
         return response;
     },
     nuxtClientInit({ commit }) {
-        const data = JSON.parse(sessionStorage.getItem('pasttime')) || []
-        console.log(data.user);
+        const data = JSON.parse(sessionStorage.getItem('pasttime')) || [];
         // if(data) {
             commit('setUser', data.user);
         // }


### PR DESCRIPTION
ログインセッション確認方法を変更
Nuxtミドルウェアで画面生成前にログイン確認通信を行い認証ユーザーではない場合にログイン画面にリダイレクト、セッションストレージ内データ削除を行う